### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/astromined/9d1ebcfa-dca0-458e-b4e8-e558d0ea4fb1/0050fde0-017a-4f8c-a5b1-8627de6e3bf9/_apis/work/boardbadge/d8b7416c-8c27-4a95-bf24-558fa29a4af8)](https://dev.azure.com/astromined/9d1ebcfa-dca0-458e-b4e8-e558d0ea4fb1/_boards/board/t/0050fde0-017a-4f8c-a5b1-8627de6e3bf9/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#166](https://dev.azure.com/astromined/9d1ebcfa-dca0-458e-b4e8-e558d0ea4fb1/_workitems/edit/166). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.